### PR TITLE
fix: add WASM artifact verification step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: |
           command -v wasm-pack || cargo install wasm-pack
           wasm-pack build --target web --out-dir ../frontend/src/wasm-pkg
+      - name: Verify WASM artifacts
+        run: |
+          test -f ../frontend/src/wasm-pkg/stitch_studio_wasm_bg.wasm || { echo "ERROR: .wasm file not found"; exit 1; }
 
   frontend:
     name: Frontend (TypeScript/React)


### PR DESCRIPTION
## Summary
- H-2対応: CIのRust (WASM)ジョブにWASMビルド成果物の存在確認ステップを追加
- `wasm-pack build` 後に `.wasm` ファイルの存在を検証し、ビルドのサイレント失敗を検知

## Test plan
- [ ] CI の rust ジョブが正常に通過すること
- [ ] WASM ビルドが成功した場合に Verify WASM artifacts ステップが pass すること