### PR TITLE
feat: stitch-studioをGitHub Pagesへ公開

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build WASM
         working-directory: wasm
         run: |
-          command -v wasm-pack || cargo install wasm-pack --version 0.14.0 --locked
+          command -v wasm-pack || cargo +stable install wasm-pack --version 0.14.0 --locked
           wasm-pack build --target web --out-dir ../frontend/src/wasm-pkg
       - name: Install frontend dependencies
         working-directory: frontend

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,24 +12,25 @@ permissions:
 
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Cache wasm-pack
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cargo/bin/wasm-pack
           key: ${{ runner.os }}-wasm-pack-0.14.0
@@ -43,12 +44,12 @@ jobs:
         run: npm ci
       - name: Configure GitHub Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Build frontend
         working-directory: frontend
         run: npm run build -- --base "${{ steps.pages.outputs.base_path }}/"
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: frontend/dist
 
@@ -66,4 +67,4 @@ jobs:
     steps:
       - name: Deploy GitHub Pages artifact
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,69 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Cache wasm-pack
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-0.14.0
+      - name: Build WASM
+        working-directory: wasm
+        run: |
+          command -v wasm-pack || cargo install wasm-pack --version 0.14.0 --locked
+          wasm-pack build --target web --out-dir ../frontend/src/wasm-pkg
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v6
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build -- --base "${{ steps.pages.outputs.base_path }}/"
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: frontend/dist
+
+  deploy:
+    name: Deploy
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Cross-stitch pattern editor powered by Rust/WASM. Convert images into stitch patterns, edit on a grid canvas, and generate thread shopping lists with DMC color matching.
 
+**Live demo:** [akaitigo.github.io/stitch-studio](https://akaitigo.github.io/stitch-studio/)
+
+Uploaded images are processed entirely in your browser and are not sent to an external service.
+
 ![stitch-studio welcome](docs/screenshots/app.png)
 
 ![stitch-studio editor](docs/screenshots/editor.png)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'"
+    />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <title>stitch-studio</title>
   </head>


### PR DESCRIPTION
## 変更内容

- GitHub Pages用のビルド・デプロイワークフローを追加
- Pagesのベースパスを`configure-pages`の出力から設定
- 本番HTMLにCSPを追加
- READMEに公開URLとブラウザ内処理のプライバシー説明を追加

## 変更理由

ローカル起動せずにアプリを試せる公開URLがなく、完成済みの静的アプリを利用者へ届けられていなかったためです。

## 利用者・開発者への影響

- `main`更新時に`https://akaitigo.github.io/stitch-studio/`へ自動デプロイされます
- Pull Requestでは公開せず、Pages向けビルドだけを検証します
- 画像は従来どおりブラウザ内で処理され、外部サービスへ送信されません

## 検証

- [x] `make check`（Rust 9件、フロントエンド70件、lint、型チェック、ビルド）
- [x] `npm run build -- --base /stitch-studio/`
- [x] Pages配下のHTML、JavaScript、CSS、WASMをローカル配信し、HTTP 200とMIME typeを確認
- [x] `actionlint .github/workflows/deploy-pages.yml`
- [x] `npm audit --omit=dev --audit-level=high`（脆弱性0件）

## セキュリティ・運用

- ビルドジョブは`contents: read`だけに制限し、`pages: write`と`id-token: write`はデプロイジョブだけに付与しています
- GitHub Pagesでは任意のレスポンスヘッダーを追加できないため、CSPはHTMLのmeta要素で補完しています
- `wasm-pack`は0.14.0に固定しています

Closes #95